### PR TITLE
Path to tested script can be supplied via CLI + slight improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
   - docker
 
 before_script:
-  - export APP_IMAGE=keboola-functional-tests-scaffolding
+  - export APP_IMAGE=keboola-datadir-tests
   - docker -v
   - docker build -t $APP_IMAGE .
   - docker run $APP_IMAGE composer ci

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Funcational tests scaffolding
 
-[![Build Status](https://travis-ci.org/keboola/functional-tests-scaffolding.svg?branch=master)](https://travis-ci.org/keboola/functional-tests-scaffolding)
+[![Build Status](https://travis-ci.org/keboola/datadir-tests.svg?branch=master)](https://travis-ci.org/keboola/datadir-tests)
 
 # Usage
 
@@ -23,7 +23,7 @@ In the tests folder create a directory structure mimicking the directory structu
 
 Then run the script with path to the tests directory.
 
-`vendor/bin/functional /path/to/tests`
+`vendor/bin/datadir-tests /path/to/tests`
 
 Result:
 
@@ -46,8 +46,8 @@ Invalid configuration for path "root.parameters.source_encoding": Source encodin
 Clone this repository and init the workspace with following command:
 
 ```
-git clone https://github.com/keboola/functional-tests-scaffolding
-cd functional-tests-scaffolding
+git clone https://github.com/keboola/datadir-tests
+cd datadir-tests
 docker-compose run --rm dev /bin/bash
 $ composer install
 $ composer ci

--- a/README.md
+++ b/README.md
@@ -23,11 +23,17 @@ In the tests folder create a directory structure mimicking the directory structu
 
 Then run the script with path to the tests directory.
 
-`vendor/bin/datadir-tests /path/to/tests`
+`vendor/bin/datadir-tests` 
+
+Or with custom tests directory and tested script:
+
+`vendor/bin/datadir-tests /tests/functional /code/src/run.php`
 
 Result:
 
 ```
+Testing "src/run.php" with tests from "tests/functional"
+
 Test "test-name"
 ✓ Suceeded
 ```

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "keboola/functional-tests-scaffolding",
+    "name": "keboola/datadir-tests",
     "description": "Tool for functional testing of Keboola Connection components",
     "license": "MIT",
     "require": {
@@ -15,7 +15,7 @@
         "phpstan/phpstan-shim": "^0.9.2"
     },
     "bin": [
-        "src/functional"
+        "src/datadir-tests"
     ],
     "scripts": {
         "phpstan": "phpstan analyse ./src ./tests --level=max --no-progress -c phpstan.neon",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "02741cdf4ca0c6529b840bc16a8494c9",
+    "content-hash": "277191517361c19713f631ad161f965b",
     "packages": [
         {
             "name": "keboola/php-temp",

--- a/src/datadir-tests
+++ b/src/datadir-tests
@@ -12,7 +12,7 @@ require_once 'vendor/autoload.php';
 
 if ($argc == 2 && (in_array($argv[1], ['-h', '--help']))) {
     print 'Usage:' . PHP_EOL;
-    print "\t" . 'functional /path/to/tests script-to-run.php' . PHP_EOL . PHP_EOL;
+    print "\t" . 'datadir-tests /path/to/tests script-to-run.php' . PHP_EOL . PHP_EOL;
     print 'All parameters are optional. Default values are "tests/functional" and "src/run.php"'  . PHP_EOL . PHP_EOL;
     exit(2);
 }

--- a/src/datadir-tests
+++ b/src/datadir-tests
@@ -10,9 +10,11 @@ use Symfony\Component\Process\Process;
 
 require_once 'vendor/autoload.php';
 
-if ($argc == 2 && (in_array($argv[1], ['-h', '--help']))) {
+if ($argc == 2 && (in_array($argv[1], ['-h', '--help', '-?']))) {
     print 'Usage:' . PHP_EOL;
-    print "\t" . 'datadir-tests /path/to/tests script-to-run.php' . PHP_EOL . PHP_EOL;
+    print "\t" . 'datadir-tests [path to tests directory] [script to test]' . PHP_EOL . PHP_EOL;
+    print 'Example:' . PHP_EOL;
+    print "\t" . 'datadir-tests /path/to/tests script-to-test.php' . PHP_EOL . PHP_EOL;
     print 'All parameters are optional. Default values are "tests/functional" and "src/run.php"'  . PHP_EOL . PHP_EOL;
     exit(2);
 }

--- a/src/functional
+++ b/src/functional
@@ -10,12 +10,30 @@ use Symfony\Component\Process\Process;
 
 require_once 'vendor/autoload.php';
 
-if ($argc !== 2) {
-    print 'Please supply tests directory as first parameter' . PHP_EOL;
+if ($argc == 2 && (in_array($argv[1], ['-h', '--help']))) {
+    print 'Usage:' . PHP_EOL;
+    print "\t" . 'functional /path/to/tests script-to-run.php' . PHP_EOL . PHP_EOL;
+    print 'All parameters are optional. Default values are "tests/functional" and "src/run.php"'  . PHP_EOL . PHP_EOL;
     exit(2);
 }
 
-$testFolder = rtrim(array_pop($argv), DIRECTORY_SEPARATOR);
+$fs = new Filesystem();
+
+$script = "src/run.php";
+if (count($argv) === 3) {
+    $script = array_pop($argv);
+    if (!$fs->exists($script)) {
+        printf('Script "%s" does not exist' . PHP_EOL, $script);
+        exit(2);
+    }
+}
+
+$testFolder = 'tests/functional';
+if (count($argv) === 2) {
+    $testFolder = rtrim(array_pop($argv), DIRECTORY_SEPARATOR);
+}
+
+printf('Testing "%s" with tests from "%s"' . PHP_EOL, $script, $testFolder);
 
 $finder = new Finder();
 $finder->directories()->sortByName()->in($testFolder)->depth(0);
@@ -32,7 +50,6 @@ foreach ($finder as $testSuite) {
     $temp = new Temp($testSuite->getBasename());
     $temp->initRunFolder();
 
-    $fs = new Filesystem();
     $fs->mirror($testSuite->getPathname() . '/source/data', $temp->getTmpFolder());
 
     $fs->mkdir($temp->getTmpFolder() . '/in/tables', 0777);
@@ -40,7 +57,7 @@ foreach ($finder as $testSuite) {
     $fs->mkdir($temp->getTmpFolder() . '/out/tables', 0777);
     $fs->mkdir($temp->getTmpFolder() . '/out/files', 0777);
 
-    $runCommand = "KBC_DATADIR={$temp->getTmpFolder()} php /code/src/run.php";
+    $runCommand = "KBC_DATADIR={$temp->getTmpFolder()} php " . $script;
     $runProcess = new Process($runCommand);
     $runProcess->run();
     if (($runProcess->getExitCode() > 0)) {


### PR DESCRIPTION
Tested on https://github.com/keboola/processor-iconv/pull/5

* Taky přejmenováno na `datadir-tests`. 