### PR TITLE
Add method for simplification common test cases

### DIFF
--- a/src/AbstractDatadirTestCase.php
+++ b/src/AbstractDatadirTestCase.php
@@ -178,6 +178,30 @@ abstract class AbstractDatadirTestCase extends TestCase
         );
     }
 
+    protected function runCommonTest(
+        string $testDirectory,
+        array $configuration,
+        int $expectedReturnCode,
+        ?string $expectedStdout,
+        ?string $expectedStderr
+    ): void {
+        $specification = new DatadirTestSpecification(
+            $testDirectory . '/source/data',
+            $expectedReturnCode,
+            $expectedStdout,
+            $expectedStderr,
+            $testDirectory . '/expected/data/out'
+        );
+
+        $tempFolder = $this->getTempDatadir($specification)->getTmpFolder();
+        file_put_contents(
+            $tempFolder . '/config.json',
+            json_encode($configuration, JSON_PRETTY_PRINT)
+        );
+        $process = $this->runScript($tempFolder);
+        $this->assertMatchesSpecification($specification, $process, $tempFolder);
+    }
+
     protected function runScript(string $datadirPath): Process
     {
         $fs = new Filesystem();

--- a/src/AbstractDatadirTestCase.php
+++ b/src/AbstractDatadirTestCase.php
@@ -178,7 +178,7 @@ abstract class AbstractDatadirTestCase extends TestCase
         );
     }
 
-    protected function runCommonTest(
+    protected function runTestWithCustomConfiguration(
         string $testDirectory,
         array $configuration,
         int $expectedReturnCode,


### PR DESCRIPTION
The new method should simplify most of test cases. I started using it here (https://github.com/keboola/db-extractor-common/blob/david-improve-tests/tests/Functional/DatadirTest.php) and consider it might be handy to have implemented in datadir-tests.

Mabe we should figure out better method name.