### PR TITLE
Custom test process timeout

### DIFF
--- a/src/AbstractDatadirTestCase.php
+++ b/src/AbstractDatadirTestCase.php
@@ -230,6 +230,7 @@ abstract class AbstractDatadirTestCase extends TestCase
         $runProcess->setEnv([
             'KBC_DATADIR' => $datadirPath,
         ]);
+        $runProcess->setTimeout(0);
         $runProcess->run();
         return $runProcess;
     }


### PR DESCRIPTION
In DWHM tests, each run may take longer than default 60s. 