### PR TITLE
Set setUp method as protected as it should be

### DIFF
--- a/src/AbstractDatadirTestCase.php
+++ b/src/AbstractDatadirTestCase.php
@@ -32,7 +32,7 @@ abstract class AbstractDatadirTestCase extends TestCase
         parent::__construct($name, $data, $dataName);
     }
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->temp = new Temp();
     }


### PR DESCRIPTION
Zatahlo se to tam omylem s opravou temp složky. A je to BC break (protože předtím fungující `protected function setUp` musí teď být public). 