### PR TITLE
Fix AbstractDatadirTestCase constructor arguments to match the parent

### DIFF
--- a/src/AbstractDatadirTestCase.php
+++ b/src/AbstractDatadirTestCase.php
@@ -24,10 +24,13 @@ abstract class AbstractDatadirTestCase extends TestCase
     /** @var Temp */
     protected $temp;
 
+    /**
+     * @inheritDoc
+     */
     public function __construct(
         ?string $name = null,
         array $data = [],
-        string $dataName = ''
+        $dataName = ''
     ) {
         $reflectionClass = new ReflectionClass(static::class);
         $this->testFileDir = dirname((string) $reflectionClass->getFileName());


### PR DESCRIPTION
Needed for https://github.com/keboola/aws-s3-extractor/pull/76

If data provider does not have keys specified for its cases (https://github.com/keboola/aws-s3-extractor/blob/1bfe12838bbe9136fc7cf71e45b88293ccfe2d4f/tests/Functional/ExceptionsFunctionalTest.php#L106) then `$dataName` is int.