### PR TITLE
AJDA-2058: BC break/feat: dropped support for php <8.2, phpunit <10, support phpunit >=10

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,10 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - phpVersion: '7.4'
-            symfonyVersion: '5.4.*'
-          - phpVersion: '8.1'
-            symfonyVersion: '6.4.*'
           - phpVersion: '8.2'
             symfonyVersion: '6.4.*'
           - phpVersion: '8.2'

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+/.claude
 /vendor
 /.idea
 /composer.lock
+/.phpunit.cache/
 /.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -3,13 +3,13 @@
     "description": "Tool for functional testing of Keboola Connection components",
     "license": "MIT",
     "require": {
-        "PHP": "^7.4|^8.0",
+        "PHP": "^8.2",
         "ext-json": "*",
         "keboola/php-temp": "^2.0",
-        "phpunit/phpunit": "^9.5",
-        "symfony/filesystem": "^5.0|^6.0|^7.0",
-        "symfony/finder": "^5.0|^6.0|^7.0",
-        "symfony/process": "^5.0|^6.0|^7.0"
+        "phpunit/phpunit": "^10.0|^11.0|^12.0",
+        "symfony/filesystem": "^6.0|^7.0",
+        "symfony/finder": "^6.0|^7.0",
+        "symfony/process": "^6.0|^7.0"
     },
     "require-dev": {
         "php-parallel-lint/php-parallel-lint": "^1.3",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
+         cacheDirectory=".phpunit.cache"
          stopOnFailure="false"
          bootstrap="tests/phpunit/bootstrap.php">
-    <testsuite name="Main Test Suite">
-        <directory>tests/phpunit</directory>
-    </testsuite>
+    <testsuites>
+        <testsuite name="Main Test Suite">
+            <directory>tests/phpunit</directory>
+        </testsuite>
+    </testsuites>
 </phpunit>

--- a/src/AbstractDatadirTestCase.php
+++ b/src/AbstractDatadirTestCase.php
@@ -18,24 +18,9 @@ use const PHP_EOL;
 
 abstract class AbstractDatadirTestCase extends TestCase
 {
-    /** @var string */
-    protected $testFileDir;
+    protected ?string $testFileDir = null;
 
-    /** @var Temp */
-    protected $temp;
-
-    /**
-     * @inheritDoc
-     */
-    public function __construct(
-        ?string $name = null,
-        array $data = [],
-        $dataName = ''
-    ) {
-        $reflectionClass = new ReflectionClass(static::class);
-        $this->testFileDir = dirname((string) $reflectionClass->getFileName());
-        parent::__construct($name, $data, $dataName);
-    }
+    protected Temp $temp;
 
     protected function setUp(): void
     {
@@ -67,6 +52,10 @@ abstract class AbstractDatadirTestCase extends TestCase
 
     public function getTestFileDir(): string
     {
+        if ($this->testFileDir === null) {
+            $reflectionClass = new ReflectionClass(static::class);
+            $this->testFileDir = dirname((string) $reflectionClass->getFileName());
+        }
         return $this->testFileDir;
     }
 

--- a/src/FunctionalDatadirTestCase.php
+++ b/src/FunctionalDatadirTestCase.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\DatadirTests;
+
+/**
+ * Test case for functional testing that stores test data internally.
+ * This is used to programmatically run tests with specific specifications.
+ *
+ * @internal
+ * @codeCoverageIgnore
+ */
+class FunctionalDatadirTestCase extends AbstractDatadirTestCase
+{
+    private ?DatadirTestSpecificationInterface $testData = null;
+
+    /**
+     * @param non-empty-string $name
+     */
+    public static function createWithData(
+        string $name,
+        DatadirTestSpecificationInterface $data,
+    ): self {
+        $instance = new self($name);
+        $instance->testData = $data;
+        return $instance;
+    }
+
+    public function initializeForTest(): void
+    {
+        $this->setUp();
+    }
+
+    /**
+     * Run the test with the stored specification.
+     * This method does not use @dataProvider - the data is set via createWithData().
+     */
+    public function testDatadir(): void
+    {
+        if ($this->testData === null) {
+            $this->markTestSkipped('No test data provided - use createWithData()');
+        }
+        $specification = $this->testData;
+        $tempDatadir = $this->getTempDatadir($specification);
+        $process = $this->runScript($tempDatadir->getTmpFolder());
+        $this->assertMatchesSpecification($specification, $process, $tempDatadir->getTmpFolder());
+    }
+
+    protected function getScript(): string
+    {
+        return __DIR__ . '/../tests/functional/dummy-app.php';
+    }
+}

--- a/tests/phpunit/DatadirTestCaseTest.php
+++ b/tests/phpunit/DatadirTestCaseTest.php
@@ -5,21 +5,22 @@ declare(strict_types=1);
 namespace Keboola\DatadirTests\Tests;
 
 use InvalidArgumentException;
-use Keboola\DatadirTests\DatadirTestCase;
 use Keboola\DatadirTests\DatadirTestsFromDirectoryProvider;
+use Keboola\DatadirTests\DatadirTestSpecificationInterface;
+use Keboola\DatadirTests\FunctionalDatadirTestCase;
 use LogicException;
+use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\TestFailure;
-use PHPUnit\Runner\BaseTestRunner;
+use Throwable;
 
 class DatadirTestCaseTest extends TestCase
 {
     public function testExpectedSuccess(): void
     {
         $test = $this->getTestCase('001-successful');
-        $result = $test->run();
+        $result = $this->runTest($test);
 
-        $this->assertEquals(BaseTestRunner::STATUS_PASSED, $test->getStatus());
+        $this->assertTrue($result->isSuccess());
 
         $this->assertEquals(0, $result->errorCount());
 
@@ -29,12 +30,13 @@ class DatadirTestCaseTest extends TestCase
 
         $this->assertCount(1, $result);
     }
+
     public function testExpectedFail(): void
     {
         $test = $this->getTestCase('002-expected-fail');
-        $result = $test->run();
+        $result = $this->runTest($test);
 
-        $this->assertEquals(BaseTestRunner::STATUS_PASSED, $test->getStatus());
+        $this->assertTrue($result->isSuccess());
 
         $this->assertEquals(0, $result->errorCount());
 
@@ -44,44 +46,47 @@ class DatadirTestCaseTest extends TestCase
 
         $this->assertCount(1, $result);
     }
+
     public function testUnexpectedFailure(): void
     {
-
         $test = $this->getTestCase('003-unexpected-failure');
-        $result = $test->run();
+        $result = $this->runTest($test);
 
-        $this->assertEquals(BaseTestRunner::STATUS_FAILURE, $test->getStatus());
+        $this->assertTrue($result->isFailure());
 
         $this->assertEquals(0, $result->errorCount());
 
         $this->assertEquals(1, $result->failureCount());
-        /** @var TestFailure[] $failures */
+        /** @var Throwable[] $failures */
         $failures = $result->failures();
         $failure = $failures[0];
-        $this->assertStringContainsString('Failed asserting exit code', $failure->exceptionMessage());
-        $this->assertStringContainsString('-0', $failure->getExceptionAsString(), 'Expected code was not 0');
-        $this->assertStringContainsString('+2', $failure->getExceptionAsString(), 'Actal code was not 2');
+        $failureString = $this->getFailureAsString($failure);
+        $this->assertStringContainsString('Failed asserting exit code', $failureString);
+        $this->assertStringContainsString('-0', $failureString, 'Expected code was not 0');
+        $this->assertStringContainsString('+2', $failureString, 'Actual code was not 2');
 
         $this->assertEquals(0, $result->skippedCount());
 
         $this->assertCount(1, $result);
     }
+
     public function testUnexpectedSuccess(): void
     {
         $test = $this->getTestCase('004-unexpected-success');
-        $result = $test->run();
+        $result = $this->runTest($test);
 
-        $this->assertEquals(BaseTestRunner::STATUS_FAILURE, $test->getStatus());
+        $this->assertTrue($result->isFailure());
 
         $this->assertEquals(0, $result->errorCount());
 
         $this->assertEquals(1, $result->failureCount());
-        /** @var TestFailure[] $failures */
+        /** @var Throwable[] $failures */
         $failures = $result->failures();
         $failure = $failures[0];
-        $this->assertStringContainsString('Failed asserting exit code', $failure->exceptionMessage());
-        $this->assertStringContainsString('-1', $failure->getExceptionAsString(), 'Expected should be 1');
-        $this->assertStringContainsString('+0', $failure->getExceptionAsString(), 'Actual should be 0');
+        $failureString = $this->getFailureAsString($failure);
+        $this->assertStringContainsString('Failed asserting exit code', $failureString);
+        $this->assertStringContainsString('-1', $failureString, 'Expected should be 1');
+        $this->assertStringContainsString('+0', $failureString, 'Actual should be 0');
 
         $this->assertEquals(0, $result->skippedCount());
 
@@ -91,9 +96,9 @@ class DatadirTestCaseTest extends TestCase
     public function testExpectedUserError(): void
     {
         $test = $this->getTestCase('005-expected-user-error');
-        $result = $test->run();
+        $result = $this->runTest($test);
 
-        $this->assertEquals(BaseTestRunner::STATUS_PASSED, $test->getStatus());
+        $this->assertTrue($result->isSuccess());
         $this->assertEquals(0, $result->errorCount());
         $this->assertEquals(0, $result->failureCount());
         $this->assertEquals(0, $result->skippedCount());
@@ -103,9 +108,9 @@ class DatadirTestCaseTest extends TestCase
     public function testExpectedInternalError(): void
     {
         $test = $this->getTestCase('006-expected-internal-error');
-        $result = $test->run();
+        $result = $this->runTest($test);
 
-        $this->assertEquals(BaseTestRunner::STATUS_PASSED, $test->getStatus());
+        $this->assertTrue($result->isSuccess());
         $this->assertEquals(0, $result->errorCount());
         $this->assertEquals(0, $result->failureCount());
         $this->assertEquals(0, $result->skippedCount());
@@ -115,9 +120,9 @@ class DatadirTestCaseTest extends TestCase
     public function testExpectedUserErrorWithOutputFolder(): void
     {
         $test = $this->getTestCase('007-expected-user-error-with-output-folder');
-        $result = $test->run();
+        $result = $this->runTest($test);
 
-        $this->assertEquals(BaseTestRunner::STATUS_PASSED, $test->getStatus());
+        $this->assertTrue($result->isSuccess());
         $this->assertEquals(0, $result->errorCount());
         $this->assertEquals(0, $result->failureCount());
         $this->assertEquals(0, $result->skippedCount());
@@ -127,24 +132,24 @@ class DatadirTestCaseTest extends TestCase
     public function testUnexpectedInternalError(): void
     {
         $test = $this->getTestCase('008-unexpected-internal-error-instead-of-user-error');
-        $result = $test->run();
+        $result = $this->runTest($test);
 
-        $this->assertEquals(BaseTestRunner::STATUS_FAILURE, $test->getStatus());
+        $this->assertTrue($result->isFailure());
         $this->assertEquals(0, $result->errorCount());
         $this->assertEquals(1, $result->failureCount());
-        /** @var TestFailure[] $failures */
+        /** @var Throwable[] $failures */
         $failures = $result->failures();
-        /** @var TestFailure $failure */
         $failure = $failures[0];
-        $this->assertStringContainsString('Failed asserting exit code', $failure->exceptionMessage());
+        $failureString = $this->getFailureAsString($failure);
+        $this->assertStringContainsString('Failed asserting exit code', $failureString);
         $this->assertStringContainsString(
             '-1',
-            $failure->getExceptionAsString(),
+            $failureString,
             'Expected exit code should have been 1',
         );
         $this->assertStringContainsString(
             '+2',
-            $failure->getExceptionAsString(),
+            $failureString,
             'Actual exit code should have been 2',
         );
 
@@ -155,24 +160,24 @@ class DatadirTestCaseTest extends TestCase
     public function testUnexpectedUserError(): void
     {
         $test = $this->getTestCase('009-unexpected-user-error-instead-of-internal-error');
-        $result = $test->run();
+        $result = $this->runTest($test);
 
-        $this->assertEquals(BaseTestRunner::STATUS_FAILURE, $test->getStatus());
+        $this->assertTrue($result->isFailure());
         $this->assertEquals(0, $result->errorCount());
         $this->assertEquals(1, $result->failureCount());
-        /** @var TestFailure[] $failures */
+        /** @var Throwable[] $failures */
         $failures = $result->failures();
-        /** @var TestFailure $failure */
         $failure = $failures[0];
-        $this->assertStringContainsString('Failed asserting exit code', $failure->exceptionMessage());
+        $failureString = $this->getFailureAsString($failure);
+        $this->assertStringContainsString('Failed asserting exit code', $failureString);
         $this->assertStringContainsString(
             '-2',
-            $failure->getExceptionAsString(),
+            $failureString,
             'Expected exit code should have been 2',
         );
         $this->assertStringContainsString(
             '+1',
-            $failure->getExceptionAsString(),
+            $failureString,
             'Actual exit code should have been 1',
         );
 
@@ -183,24 +188,24 @@ class DatadirTestCaseTest extends TestCase
     public function testUnexpectedSuccessWithExplicitlyExpectedError(): void
     {
         $test = $this->getTestCase('011-unexpected-success-with-explicitly-expected-exit-code');
-        $result = $test->run();
+        $result = $this->runTest($test);
 
-        $this->assertEquals(BaseTestRunner::STATUS_FAILURE, $test->getStatus());
+        $this->assertTrue($result->isFailure());
         $this->assertEquals(0, $result->errorCount());
         $this->assertEquals(1, $result->failureCount());
-        /** @var TestFailure[] $failures */
+        /** @var Throwable[] $failures */
         $failures = $result->failures();
-        /** @var TestFailure $failure */
         $failure = $failures[0];
-        $this->assertStringContainsString('Failed asserting exit code', $failure->exceptionMessage());
+        $failureString = $this->getFailureAsString($failure);
+        $this->assertStringContainsString('Failed asserting exit code', $failureString);
         $this->assertStringContainsString(
             '-1',
-            $failure->getExceptionAsString(),
+            $failureString,
             'Expected exit code should have been 1',
         );
         $this->assertStringContainsString(
             '+0',
-            $failure->getExceptionAsString(),
+            $failureString,
             'Actual exit code should have been 0',
         );
 
@@ -223,13 +228,12 @@ class DatadirTestCaseTest extends TestCase
         $this->getTestCase('012-neither-code-or-folder');
     }
 
-
     public function testExpectedStdoutMatch(): void
     {
         $test = $this->getTestCase('013-expected-stdout-match');
-        $result = $test->run();
+        $result = $this->runTest($test);
 
-        $this->assertEquals(BaseTestRunner::STATUS_PASSED, $test->getStatus());
+        $this->assertTrue($result->isSuccess());
         $this->assertEquals(0, $result->errorCount());
         $this->assertEquals(0, $result->failureCount());
         $this->assertEquals(0, $result->skippedCount());
@@ -239,31 +243,30 @@ class DatadirTestCaseTest extends TestCase
     public function testExpectedStdoutNotMatch(): void
     {
         $test = $this->getTestCase('014-expected-stdout-not-match');
-        $result = $test->run();
+        $result = $this->runTest($test);
 
-        $this->assertEquals(BaseTestRunner::STATUS_FAILURE, $test->getStatus());
+        $this->assertTrue($result->isFailure());
         $this->assertEquals(0, $result->errorCount());
         $this->assertEquals(1, $result->failureCount());
         $this->assertEquals(0, $result->skippedCount());
         $this->assertCount(1, $result);
 
-        /** @var TestFailure[] $failures */
+        /** @var Throwable[] $failures */
         $failures = $result->failures();
-        /** @var TestFailure $failure */
         $failure = $failures[0];
-        $error = $failure->getExceptionAsString();
-        $this->assertStringContainsString('Failed asserting stdout output', $error);
-        $this->assertStringContainsString('Failed asserting that string matches format description', $error);
-        $this->assertStringContainsString("-another message\n", $error);
-        $this->assertStringContainsString("+stdout message '12345'\n", $error);
+        $failureString = $this->getFailureAsString($failure);
+        $this->assertStringContainsString('Failed asserting stdout output', $failureString);
+        $this->assertStringContainsString('Failed asserting that string matches format description', $failureString);
+        $this->assertStringContainsString("-another message\n", $failureString);
+        $this->assertStringContainsString("+stdout message '12345'\n", $failureString);
     }
 
     public function testExpectedStderrMatch(): void
     {
         $test = $this->getTestCase('015-expected-stderr-match');
-        $result = $test->run();
+        $result = $this->runTest($test);
 
-        $this->assertEquals(BaseTestRunner::STATUS_PASSED, $test->getStatus());
+        $this->assertTrue($result->isSuccess());
         $this->assertEquals(0, $result->errorCount());
         $this->assertEquals(0, $result->failureCount());
         $this->assertEquals(0, $result->skippedCount());
@@ -273,32 +276,31 @@ class DatadirTestCaseTest extends TestCase
     public function testExpectedStderrNotMatch(): void
     {
         $test = $this->getTestCase('016-expected-stderr-not-match');
-        $result = $test->run();
+        $result = $this->runTest($test);
 
-        $this->assertEquals(BaseTestRunner::STATUS_FAILURE, $test->getStatus());
+        $this->assertTrue($result->isFailure());
         $this->assertEquals(0, $result->errorCount());
         $this->assertEquals(1, $result->failureCount());
         $this->assertEquals(0, $result->skippedCount());
         $this->assertCount(1, $result);
 
-        /** @var TestFailure[] $failures */
+        /** @var Throwable[] $failures */
         $failures = $result->failures();
-        /** @var TestFailure $failure */
         $failure = $failures[0];
-        $error = $failure->getExceptionAsString();
-        $this->assertStringContainsString('Failed asserting stderr output', $error);
-        $this->assertStringContainsString('Failed asserting that string matches format description', $error);
-        $this->assertStringContainsString("-another message\n", $error);
-        $this->assertStringContainsString("+stderr message '12345'\n", $error);
+        $failureString = $this->getFailureAsString($failure);
+        $this->assertStringContainsString('Failed asserting stderr output', $failureString);
+        $this->assertStringContainsString('Failed asserting that string matches format description', $failureString);
+        $this->assertStringContainsString("-another message\n", $failureString);
+        $this->assertStringContainsString("+stderr message '12345'\n", $failureString);
     }
 
     public function testModifyConfig(): void
     {
         putenv('MY_TEST_VAR_123=some simple message');
         $test = $this->getTestCase('017-modify-config');
-        $result = $test->run();
+        $result = $this->runTest($test);
 
-        $this->assertEquals(BaseTestRunner::STATUS_PASSED, $test->getStatus());
+        $this->assertTrue($result->isSuccess());
         $this->assertEquals(0, $result->errorCount());
         $this->assertEquals(0, $result->failureCount());
         $this->assertEquals(0, $result->skippedCount());
@@ -308,33 +310,48 @@ class DatadirTestCaseTest extends TestCase
     public function testInvalidConfig(): void
     {
         $test = $this->getTestCase('018-invalid-config');
-        $result = $test->run();
+        $result = $this->runTest($test);
 
-        $this->assertEquals(BaseTestRunner::STATUS_ERROR, $test->getStatus());
+        $this->assertTrue($result->isError());
         $this->assertEquals(1, $result->errorCount());
         $this->assertEquals(0, $result->failureCount());
         $this->assertEquals(0, $result->skippedCount());
 
         $errors = $result->errors();
         $error = $errors[0];
-        $error = $error->getExceptionAsString();
+        $errorString = (string) $error;
         $this->assertStringContainsString(
-            'Keboola\DatadirTests\Exception\DatadirTestsException: ' .
-            'Cannot decode "config.json", dataset "functional": Syntax error',
-            $error,
+            'Keboola\DatadirTests\Exception\DatadirTestsException',
+            $errorString,
         );
+        $this->assertStringContainsString('Cannot decode "config.json"', $errorString);
+        $this->assertStringContainsString('Syntax error', $errorString);
     }
 
-    protected function getTestCase(string $path): DatadirTestCase
+    protected function runTest(FunctionalDatadirTestCase $test): TestResultCollector
+    {
+        $result = new TestResultCollector();
+        $result->run($test);
+        return $result;
+    }
+
+    protected function getTestCase(string $path): FunctionalDatadirTestCase
     {
         $datadirTestsFromDirectoryProvider = new DatadirTestsFromDirectoryProvider(__DIR__ . '/../functional/' . $path);
         $data = $datadirTestsFromDirectoryProvider();
-        return new class('testDatadir', $data['functional'], 'functional') extends DatadirTestCase
-        {
-            protected function getScript(): string
-            {
-                return __DIR__ . '/../functional/dummy-app.php';
-            }
-        };
+
+        return FunctionalDatadirTestCase::createWithData('testDatadir', $data['functional'][0]);
+    }
+
+    /**
+     * Get the full failure message including the comparison diff.
+     */
+    protected function getFailureAsString(Throwable $failure): string
+    {
+        $message = $failure->getMessage();
+        if ($failure instanceof ExpectationFailedException && $failure->getComparisonFailure() !== null) {
+            $message .= "\n" . $failure->getComparisonFailure()->getDiff();
+        }
+        return $message;
     }
 }

--- a/tests/phpunit/EnvVarProcessorTest.php
+++ b/tests/phpunit/EnvVarProcessorTest.php
@@ -8,15 +8,13 @@ use Keboola\DatadirTests\EnvVarProcessor;
 use Keboola\DatadirTests\Exception\EnvVariableNotFoundException;
 use Keboola\DatadirTests\Exception\UnexpectedTypeException;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class EnvVarProcessorTest extends TestCase
 {
-    /**
-     * @dataProvider getValidInputs
-     * @param mixed $expected
-     */
-    public function testEvaluateExpr(?string $var, ?string $value, string $statement, $expected): void
+    #[DataProvider('getValidInputs')]
+    public function testEvaluateExpr(?string $var, ?string $value, string $statement, mixed $expected): void
     {
         if ($var) {
             putenv("$var=$value");
@@ -26,7 +24,10 @@ class EnvVarProcessorTest extends TestCase
         Assert::assertSame($expected, $processor->evaluateExpr($statement));
     }
 
-    public function getValidInputs(): array
+    /**
+     * @return array<string, array{0: ?string, 1: ?string, 2: string, 3: mixed}>
+     */
+    public static function getValidInputs(): array
     {
         return [
             'no_var_1' => [null, null, 'abc', 'abc'],

--- a/tests/phpunit/TestResultCollector.php
+++ b/tests/phpunit/TestResultCollector.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\DatadirTests\Tests;
+
+use Countable;
+use Keboola\DatadirTests\FunctionalDatadirTestCase;
+use PHPUnit\Framework\AssertionFailedError;
+use Throwable;
+
+/**
+ * Helper class to collect test results in PHPUnit 10+ style.
+ * Mimics the old TestResult API for backwards compatibility in tests.
+ */
+class TestResultCollector implements Countable
+{
+    /** @var int<0, max> */
+    private int $errorCount = 0;
+    /** @var int<0, max> */
+    private int $failureCount = 0;
+    /** @var int<0, max> */
+    private int $skippedCount = 0;
+    /** @var int<0, max> */
+    private int $testCount = 0;
+
+    /** @var array<int, Throwable> */
+    private array $failures = [];
+
+    /** @var array<int, Throwable> */
+    private array $errors = [];
+
+    private bool $isSuccess = false;
+    private bool $isFailure = false;
+    private bool $isError = false;
+
+    public function run(FunctionalDatadirTestCase $test): void
+    {
+        $this->testCount = 1;
+        $test->initializeForTest();
+
+        try {
+            // Get the test method name from the test
+            $testMethod = $test->name();
+            $test->$testMethod();
+            $this->isSuccess = true;
+        } catch (AssertionFailedError $e) {
+            $this->isFailure = true;
+            $this->failureCount = 1;
+            $this->failures[] = $e;
+        } catch (Throwable $e) {
+            $this->isError = true;
+            $this->errorCount = 1;
+            $this->errors[] = $e;
+        }
+    }
+
+    public function errorCount(): int
+    {
+        return $this->errorCount;
+    }
+
+    public function failureCount(): int
+    {
+        return $this->failureCount;
+    }
+
+    public function skippedCount(): int
+    {
+        return $this->skippedCount;
+    }
+
+    /**
+     * @return int<0, max>
+     */
+    public function count(): int
+    {
+        return $this->testCount;
+    }
+
+    public function isSuccess(): bool
+    {
+        return $this->isSuccess;
+    }
+
+    public function isFailure(): bool
+    {
+        return $this->isFailure;
+    }
+
+    public function isError(): bool
+    {
+        return $this->isError;
+    }
+
+    /**
+     * @return array<int, Throwable>
+     */
+    public function failures(): array
+    {
+        return $this->failures;
+    }
+
+    /**
+     * @return array<int, Throwable>
+     */
+    public function errors(): array
+    {
+        return $this->errors;
+    }
+}


### PR DESCRIPTION
- **BC break**: Dropped support for php <8.2, phpunit <10
- **feat**: Rewritten to work with phpunit >=10

This pull request introduces several updates focused on modernizing dependencies, improving compatibility with newer PHP and PHPUnit versions, and refactoring test cases for better maintainability and clarity. The most significant changes include updating the minimum PHP version and package requirements, refactoring test case logic to work with newer PHPUnit APIs, and introducing a new functional test case class.

**Dependency and Compatibility Updates:**

* Updated the minimum required PHP version to `^8.2` and bumped `phpunit/phpunit` to support versions `^10.0|^11.0|^12.0`. Also, restricted `symfony/filesystem`, `symfony/finder`, and `symfony/process` dependencies to versions `^6.0|^7.0` for better compatibility with modern PHP. (`composer.json`)
* Refreshed the PHPUnit configuration in `phpunit.xml.dist` to use the schema for newer PHPUnit versions, added a cache directory, and reorganized test suite definitions. (`phpunit.xml.dist`)

**Test Case Refactoring and Improvements:**

* Refactored `AbstractDatadirTestCase` to use typed properties and lazy initialization for `testFileDir`, improving compatibility with newer PHPUnit and PHP versions. (`src/AbstractDatadirTestCase.php`) [[1]](diffhunk://#diff-923b2cd9152d23a620a0a22cd69b18a566ab1d14d817d4cf76a783f57b9c82b5L21-R23) [[2]](diffhunk://#diff-923b2cd9152d23a620a0a22cd69b18a566ab1d14d817d4cf76a783f57b9c82b5R55-R58)
* Added `FunctionalDatadirTestCase`, a new class for programmatically running datadir tests with specific specifications, supporting internal storage of test data and direct invocation of test logic. (`src/FunctionalDatadirTestCase.php`)

**Test Suite Modernization:**

* Updated `DatadirTestCaseTest` to replace legacy PHPUnit test status assertions with modern result checks (`isSuccess()`, `isFailure()`), and refactored failure inspection logic to work with `Throwable` instead of `TestFailure`. This improves reliability and compatibility with PHPUnit 10+. (`tests/phpunit/DatadirTestCaseTest.php`) [[1]](diffhunk://#diff-01d7116538c3bfdfb3207eafb6cc91aebcb2a6503e727745d3d37011b63ebfb1L8-R23) [[2]](diffhunk://#diff-01d7116538c3bfdfb3207eafb6cc91aebcb2a6503e727745d3d37011b63ebfb1R33-R39) [[3]](diffhunk://#diff-01d7116538c3bfdfb3207eafb6cc91aebcb2a6503e727745d3d37011b63ebfb1R49-R89) [[4]](diffhunk://#diff-01d7116538c3bfdfb3207eafb6cc91aebcb2a6503e727745d3d37011b63ebfb1L94-R101) [[5]](diffhunk://#diff-01d7116538c3bfdfb3207eafb6cc91aebcb2a6503e727745d3d37011b63ebfb1L106-R113) [[6]](diffhunk://#diff-01d7116538c3bfdfb3207eafb6cc91aebcb2a6503e727745d3d37011b63ebfb1L118-R125) [[7]](diffhunk://#diff-01d7116538c3bfdfb3207eafb6cc91aebcb2a6503e727745d3d37011b63ebfb1L130-R152) [[8]](diffhunk://#diff-01d7116538c3bfdfb3207eafb6cc91aebcb2a6503e727745d3d37011b63ebfb1L158-R180) [[9]](diffhunk://#diff-01d7116538c3bfdfb3207eafb6cc91aebcb2a6503e727745d3d37011b63ebfb1L186-R208) [[10]](diffhunk://#diff-01d7116538c3bfdfb3207eafb6cc91aebcb2a6503e727745d3d37011b63ebfb1L226-R236) [[11]](diffhunk://#diff-01d7116538c3bfdfb3207eafb6cc91aebcb2a6503e727745d3d37011b63ebfb1L242-R269) [[12]](diffhunk://#diff-01d7116538c3bfdfb3207eafb6cc91aebcb2a6503e727745d3d37011b63ebfb1L276-R303)

These changes collectively ensure that the project is ready for modern PHP and PHPUnit versions, improve test reliability, and make the codebase easier to maintain.